### PR TITLE
Build request - attempt 2 14/4/26 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
             })
 
       - name: Install protobuf compiler
-        run: sudo apt-get install -y protobuf-compiler
+        run: apt-get install -y protobuf-compiler
 
       - name: Run the nori-bridge-head workflow, run integration tests and build images.
         shell: bash


### PR DESCRIPTION
Latest release of bridge-head with the PR:

- https://github.com/Nori-zk/nori-bridge-head/pull/44

Release notes:

- https://github.com/Nori-zk/nori-bridge-head/blob/develop/CHANGELOG.md#24226--sp1-v5v6-migration
- Also since this PR was merged had to downgrade to sp1 v6.0.1 due to build/network failures
- Upgraded proof-systems to 0.6
- FIX: removing sudo from protobuf compiler install