### PR TITLE
Add SP1_MIN_AUCTION_PERIOD_SECS, SP1_WHITELIST_OPEN and SP1_WHITELIST_ADD_DEFAULT config options 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,6 +68,13 @@ SP1_NETWORK_PRIVATE_KEY=
 # Default: 30 seconds
 # SP1_AUCTION_TIMEOUT_SECS=30
 
+# SP1_MIN_AUCTION_PERIOD_SECS: Minimum time the auction stays open before settling
+# The auction settles only after this period AND >= 1 bid is received.
+# Only used when SP1_FULFILLMENT_STRATEGY=auction
+# Recommended: 10-15 if you don't have strict latency requirements (better price discovery)
+# Default: 1 second
+# SP1_MIN_AUCTION_PERIOD_SECS=1
+
 # SP1_MAX_PRICE_PER_PGU: The maximum amount of PROVE per PGU
 # Only used when SP1_FULFILLMENT_STRATEGY=auction
 # Default: ??? (2.0000 $PROVE)

--- a/.env.example
+++ b/.env.example
@@ -106,3 +106,24 @@ SP1_NETWORK_PRIVATE_KEY=
 # Example: 0x1234...,0x5678...,0x9abc...
 # SP1_WHITELIST=
 
+# SP1_WHITELIST_OPEN: Opt out of any whitelist - send an empty list to the prover network,
+# meaning any prover can bid on the auction.
+# Only meaningful when SP1_WHITELIST is NOT set, and mutually exclusive with SP1_WHITELIST.
+# When unset (default), the SDK silently injects all recently reliable provers as the
+# whitelist (and may retry with high-availability provers on auction failure).
+# Setting this to true sends Some(vec![]) to the SDK, bypassing both behaviours.
+# Options: true, false
+# Default: false
+# SP1_WHITELIST_OPEN=false
+
+# SP1_WHITELIST_ADD_DEFAULT: When true, extends SP1_WHITELIST with the SDK default pool
+# of recently reliable provers (get_provers_by_uptime, high_availability_only: false) -
+# the same set the SDK would have injected if no whitelist was provided.
+# Same shape as SP1_WHITELIST_ADD_HIGH_AVAILABILITY but the broader pool. Useful when you
+# want to whitelist a specific prover AND keep the default fallback set as well. Both
+# extension flags can be enabled together (their results are merged and deduplicated).
+# Only applies when SP1_WHITELIST is provided.
+# Options: true, false
+# Default: false
+# SP1_WHITELIST_ADD_DEFAULT=false
+

--- a/README.md
+++ b/README.md
@@ -77,10 +77,42 @@ NORI_LOG=info
 - **SP1_CYCLE_LIMIT**: Max cycles. Only required when `SP1_SKIP_SIMULATION=true`; otherwise SP1 calculates from simulation (defaults when required: Mainnet=1T, Reserved=100M)
 - **SP1_GAS_LIMIT**: Gas limit. Only required when `SP1_SKIP_SIMULATION=true`; otherwise SP1 calculates from simulation (default when required: 1B)
 - **SP1_TIMEOUT_SECS**: Overall timeout in seconds (default: 600 / 10 minutes)
-- **SP1_WHITELIST**: Comma-separated list of prover addresses to whitelist. If not set, SDK uses recently reliable provers (optional)
-- **SP1_WHITELIST_ADD_HIGH_AVAILABILITY**: When `true`, extends the configured whitelist with high-availability provers from the network. Only applies when `SP1_WHITELIST` is provided. Useful for ensuring backup provers are available - `true` or `false` (default: `false`, optional)
+- **Whitelist (auction bidder restriction)**: see [Whitelist configuration](#whitelist-configuration) below
 
 See `.env.example`
+
+#### Whitelist configuration
+
+Only relevant when `SP1_FULFILLMENT_STRATEGY=auction`. The whitelist tells the prover network which provers are allowed to bid on your request.
+
+There are three pools the SDK / our code can pull from:
+
+| Pool | Source |
+|---|---|
+| **User list** | Addresses you set in `SP1_WHITELIST` |
+| **Default pool** | `get_provers_by_uptime(high_availability_only: false)` — every recently reliable prover. This is the set the SDK silently injects when you provide no whitelist. |
+| **HA subset** | `get_provers_by_uptime(high_availability_only: true)` — the high-availability subset of the default pool. |
+
+**Variables:**
+
+- **`SP1_WHITELIST`** *(optional)* — Comma-separated prover addresses. If set, the auction is restricted to *exactly* these provers (unless extended via the flags below).
+- **`SP1_WHITELIST_ADD_HIGH_AVAILABILITY`** *(`true` / `false`, default `false`)* — Extension flag. Requires `SP1_WHITELIST`. When `true`, merges the HA subset into the user list.
+- **`SP1_WHITELIST_ADD_DEFAULT`** *(`true` / `false`, default `false`)* — Extension flag. Requires `SP1_WHITELIST`. When `true`, merges the default pool into the user list. Can be combined with `SP1_WHITELIST_ADD_HIGH_AVAILABILITY`; merges are deduplicated.
+- **`SP1_WHITELIST_OPEN`** *(`true` / `false`, default `false`)* — Open-auction flag. Mutually exclusive with `SP1_WHITELIST`. When `true`, sends an empty whitelist on the wire, which the network interprets as "any prover can bid." Also disables the SDK's auction-failure retry-with-HA-fallback (which only fires when the whitelist is left unset).
+
+**Regimes (combinations of the four vars above):**
+
+| `SP1_WHITELIST` | `..._ADD_HIGH_AVAILABILITY` | `..._ADD_DEFAULT` | `SP1_WHITELIST_OPEN` | What gets sent to the network |
+|---|---|---|---|---|
+| unset | — | — | unset / `false` | **SDK default** — SDK auto-injects the default pool client-side; on auction failure, retries with the HA subset |
+| unset | — | — | `true` | **Empty list** — any prover can bid; no SDK auto-injection, no fallback retry |
+| `0xA,0xB` | `false` | `false` | unset | **Exactly `0xA, 0xB`** |
+| `0xA,0xB` | `true` | `false` | unset | **`0xA, 0xB` ∪ HA subset** |
+| `0xA,0xB` | `false` | `true` | unset | **`0xA, 0xB` ∪ default pool** |
+| `0xA,0xB` | `true` | `true` | unset | **`0xA, 0xB` ∪ HA subset ∪ default pool** (deduplicated) |
+
+Invalid combinations (config will error on startup):
+- `SP1_WHITELIST` set together with `SP1_WHITELIST_OPEN=true`
 
 ### Example Configurations
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ NORI_LOG=info
 - **SP1_NETWORK_MODE**: Network type - `mainnet` or `reserved` (default: `mainnet`)
 - **SP1_FULFILLMENT_STRATEGY**: Fulfillment method - `auction`, `hosted`, or `reserved` (defaults: Mainnet=`auction`, Reserved=`reserved`)
 - **SP1_AUCTION_TIMEOUT_SECS**: Auction timeout in seconds, only used when strategy is `auction` (default: 30)
+- **SP1_MIN_AUCTION_PERIOD_SECS**: Minimum time (seconds) the auction must remain open before settling, only used when strategy is `auction`. The auction settles only after this period has elapsed AND at least one bid is received. Recommended 10-15 if you don't have strict latency requirements, to give bidders time to compete and improve pricing (default: 1)
 - **SP1_MAX_PRICE_PER_PGU**: Maximum price per PGU (default: 1,000,000,000 / 1.0 $PROVE)
 - **SP1_SKIP_SIMULATION**: Skip simulation step - `true` or `false`. When `true`, you must provide cycle/gas limits (default: `false`)
 - **SP1_CYCLE_LIMIT**: Max cycles. Only required when `SP1_SKIP_SIMULATION=true`; otherwise SP1 calculates from simulation (defaults when required: Mainnet=1T, Reserved=100M)

--- a/nori/src/sp1_prover.rs
+++ b/nori/src/sp1_prover.rs
@@ -258,41 +258,57 @@ pub async fn finality_update_job(
     let encoded_proof_inputs = serde_cbor::to_vec(&inputs)?;
     info!("Encoded sp1 proof inputs.");
 
-    // Fetch and extend whitelist if needed
+    // Fetch and extend whitelist if either extension flag is set. Both flags can be active
+    // at once (HA subset + default pool); duplicates are removed and original order is kept.
     let extended_whitelist = match &config.mode {
-        ProverMode::Network(net) if net.whitelist_add_high_availability => {
-            info!("Fetching high-availability provers to extend whitelist...");
-            match try_get_fallback_whitelist(net).await {
-                Ok(fallback) => {
-                    info!("Successfully fetched {} high-availability provers.", fallback.len());
+        ProverMode::Network(net)
+            if net.whitelist_add_high_availability || net.whitelist_add_default =>
+        {
+            let mut extended = net.whitelist.clone().unwrap_or_default();
+            let mut seen: HashSet<Address> = extended.iter().copied().collect();
 
-                    // Extend the existing whitelist with fallback provers (deduplicated, order preserved)
-                    let mut extended = net.whitelist.clone().unwrap_or_default();
-                    let mut seen: HashSet<Address> = extended.iter().copied().collect();
-
-                    let mut added_count = 0;
-                    for addr in fallback {
-                        if seen.insert(addr) {
-                            extended.push(addr);
-                            added_count += 1;
-                        }
+            let mut append_unique = |label: &str, fetched: Vec<Address>| {
+                let mut added = 0;
+                for addr in fetched {
+                    if seen.insert(addr) {
+                        extended.push(addr);
+                        added += 1;
                     }
-
-                    info!(
-                        "Whitelist extended with {} new provers (total: {}):",
-                        added_count,
-                        extended.len()
-                    );
-                    for addr in &extended {
-                        info!("  - {}", addr);
-                    }
-                    Some(extended)
                 }
-                Err(e) => {
-                    info!("Failed to fetch high-availability provers: {}. Using configured whitelist only.", e);
-                    net.whitelist.clone()
+                info!("Added {} {} provers (after dedup).", added, label);
+            };
+
+            if net.whitelist_add_high_availability {
+                info!("Fetching high-availability provers to extend whitelist...");
+                match try_get_fallback_whitelist(net, true).await {
+                    Ok(fallback) => {
+                        info!("Successfully fetched {} high-availability provers.", fallback.len());
+                        append_unique("high-availability", fallback);
+                    }
+                    Err(e) => {
+                        info!("Failed to fetch high-availability provers: {}. Skipping HA extension.", e);
+                    }
                 }
             }
+
+            if net.whitelist_add_default {
+                info!("Fetching default-pool provers to extend whitelist...");
+                match try_get_fallback_whitelist(net, false).await {
+                    Ok(default_pool) => {
+                        info!("Successfully fetched {} default-pool provers.", default_pool.len());
+                        append_unique("default-pool", default_pool);
+                    }
+                    Err(e) => {
+                        info!("Failed to fetch default-pool provers: {}. Skipping default-pool extension.", e);
+                    }
+                }
+            }
+
+            info!("Whitelist after extensions (total: {}):", extended.len());
+            for addr in &extended {
+                info!("  - {}", addr);
+            }
+            Some(extended)
         }
         _ => None,
     };

--- a/nori/src/sp1_prover.rs
+++ b/nori/src/sp1_prover.rs
@@ -127,9 +127,15 @@ async fn generate_proof(
             // Apply the strategy
             proof_request = proof_request.strategy(strategy);
 
-            // Apply the auction timeout if and only if we are in Auction mode
-            if let FulfillmentConfig::Auction { timeout } = net.fulfillment {
-                proof_request = proof_request.auction_timeout(timeout);
+            // Apply the auction timeout and min auction period if and only if we are in Auction mode
+            if let FulfillmentConfig::Auction {
+                timeout,
+                min_auction_period,
+            } = net.fulfillment
+            {
+                proof_request = proof_request
+                    .auction_timeout(timeout)
+                    .min_auction_period(min_auction_period);
             }
 
             // Use the extended whitelist if provided, otherwise use the config's whitelist

--- a/nori/src/sp1_prover_config.rs
+++ b/nori/src/sp1_prover_config.rs
@@ -56,6 +56,21 @@ const ENV_SP1_WHITELIST: &str = "SP1_WHITELIST"; // Maps to ProveRequest.whiteli
 // A custom env (a boolean) to use a query to add the provers with the best uptime (high_availability_only: true) to the whitelist before starting
 const ENV_SP1_WHITELIST_ADD_HIGH_AVAILABILITY: &str = "SP1_WHITELIST_ADD_HIGH_AVAILABILITY";
 
+// A custom env (a boolean) to extend SP1_WHITELIST with the SDK default pool of recently
+// reliable provers (get_provers_by_uptime with high_availability_only: false). Same shape
+// as SP1_WHITELIST_ADD_HIGH_AVAILABILITY but uses the broader pool. Only meaningful when
+// SP1_WHITELIST is set; ignored otherwise.
+const ENV_SP1_WHITELIST_ADD_DEFAULT: &str = "SP1_WHITELIST_ADD_DEFAULT";
+
+// Opt-in: when SP1_WHITELIST is unset and SP1_WHITELIST_OPEN=true, send an empty whitelist
+// to the prover network (= "any prover can participate" per the auction proto).
+// This bypasses the SDK's default behaviour at sp1-sdk-6.1.0/src/network/client.rs:614-623,
+// where a `None` whitelist is silently replaced by all recently reliable provers fetched
+// via get_provers_by_uptime. Also disables the auction-failure retry-with-fallback path
+// at sp1-sdk-6.1.0/src/network/prover.rs:691, which only fires when whitelist.is_none().
+// Reference: sp1-sdk-6.1.0/src/network/proto/auction/types.rs:125-126
+const ENV_SP1_WHITELIST_OPEN: &str = "SP1_WHITELIST_OPEN";
+
 // Default values from sp1-sdk-5.2.2
 
 // 1 PROVE (18 decimals). from 5.2.2/src/network/prove.rs Line 508 wrong value TODO
@@ -115,12 +130,24 @@ pub struct NetworkConfig {
     pub timeout: Duration,
     pub whitelist: Option<Vec<Address>>,
     pub whitelist_add_high_availability: bool,
+    pub whitelist_add_default: bool,
 }
 
-// Get a set of high availability fallback provers
-pub async fn get_fallback_whitelist(config: &NetworkConfig) -> anyhow::Result<Vec<Address>> {
+// Get a set of fallback provers. When `high_availability_only` is true the returned set
+// is restricted to the network's high-availability subset; when false it is the full
+// recently-reliable pool (the same set the SDK injects when no whitelist is provided).
+pub async fn get_fallback_whitelist(
+    config: &NetworkConfig,
+    high_availability_only: bool,
+) -> anyhow::Result<Vec<Address>> {
     const MAX_RETRIES: u32 = 3;
     const INITIAL_BACKOFF_MS: u64 = 500;
+
+    let label = if high_availability_only {
+        "high-availability"
+    } else {
+        "default-pool"
+    };
 
     let mut attempt = 0;
     let mut backoff_ms = INITIAL_BACKOFF_MS;
@@ -128,27 +155,28 @@ pub async fn get_fallback_whitelist(config: &NetworkConfig) -> anyhow::Result<Ve
     loop {
         attempt += 1;
 
-        match try_get_fallback_whitelist(config).await {
+        match try_get_fallback_whitelist(config, high_availability_only).await {
             Ok(whitelist) => {
                 if attempt > 1 {
                     info!(
-                        "Successfully fetched high-availability provers on attempt {}",
-                        attempt
+                        "Successfully fetched {} provers on attempt {}",
+                        label, attempt
                     );
                 }
                 return Ok(whitelist);
             }
             Err(e) if attempt >= MAX_RETRIES => {
                 return Err(anyhow::anyhow!(
-                    "Failed to fetch high-availability provers after {} attempts: {}",
+                    "Failed to fetch {} provers after {} attempts: {}",
+                    label,
                     MAX_RETRIES,
                     e
                 ));
             }
             Err(e) => {
                 info!(
-                    "Failed to fetch high-availability provers (attempt {}/{}): {}. Retrying in {}ms...",
-                    attempt, MAX_RETRIES, e, backoff_ms
+                    "Failed to fetch {} provers (attempt {}/{}): {}. Retrying in {}ms...",
+                    label, attempt, MAX_RETRIES, e, backoff_ms
                 );
                 tokio::time::sleep(Duration::from_millis(backoff_ms)).await;
                 backoff_ms *= 2; // Exponential backoff
@@ -157,7 +185,10 @@ pub async fn get_fallback_whitelist(config: &NetworkConfig) -> anyhow::Result<Ve
     }
 }
 
-pub async fn try_get_fallback_whitelist(config: &NetworkConfig) -> anyhow::Result<Vec<Address>> {
+pub async fn try_get_fallback_whitelist(
+    config: &NetworkConfig,
+    high_availability_only: bool,
+) -> anyhow::Result<Vec<Address>> {
     // Ensure crypto provider is installed (only happens once globally)
     ensure_crypto_provider();
 
@@ -167,7 +198,7 @@ pub async fn try_get_fallback_whitelist(config: &NetworkConfig) -> anyhow::Resul
     let fallback_whitelist = auction_network_client
         .get_provers_by_uptime(
             sp1_sdk::network::proto::auction_types::GetProversByUptimeRequest {
-                high_availability_only: true,
+                high_availability_only,
             },
         )
         .await?
@@ -487,6 +518,54 @@ impl ProverConfig {
                     None => false,
                 };
 
+                // If a whitelist is provided, optionally include the SDK default pool of
+                // recently reliable provers. Same shape as whitelist_add_high_availability
+                // but uses high_availability_only: false.
+                let whitelist_add_default = match &whitelist {
+                    Some(_) => env::var(ENV_SP1_WHITELIST_ADD_DEFAULT).map_or(
+                        Ok(false),
+                        |val| {
+                            val.parse::<bool>().with_context(|| {
+                                format!(
+                                    "Failed to parse {} as bool. Got: '{}'",
+                                    ENV_SP1_WHITELIST_ADD_DEFAULT, val
+                                )
+                            })
+                        },
+                    )?,
+                    None => false,
+                };
+
+                // SP1_WHITELIST_OPEN: when true with no SP1_WHITELIST, send an empty whitelist
+                // (= any prover can participate). Mutually exclusive with SP1_WHITELIST.
+                // Behaviour: parse as bool or error on invalid, default false.
+                let whitelist_open = match env::var(ENV_SP1_WHITELIST_OPEN) {
+                    Ok(val) => val.parse::<bool>().with_context(|| {
+                        format!(
+                            "Failed to parse {} as bool. Got: '{}'. Expected 'true' or 'false'",
+                            ENV_SP1_WHITELIST_OPEN, val
+                        )
+                    })?,
+                    Err(_) => false,
+                };
+
+                if whitelist_open && whitelist.is_some() {
+                    return Err(anyhow::anyhow!(
+                        "{} and {} are mutually exclusive. Set {} to opt out of any whitelist, \
+                         or provide {} to restrict bidders — not both.",
+                        ENV_SP1_WHITELIST_OPEN,
+                        ENV_SP1_WHITELIST,
+                        ENV_SP1_WHITELIST_OPEN,
+                        ENV_SP1_WHITELIST
+                    ));
+                }
+
+                let whitelist = if whitelist_open {
+                    Some(Vec::new())
+                } else {
+                    whitelist
+                };
+
                 ProverMode::Network(NetworkConfig {
                     network_mode,
                     private_key,
@@ -499,6 +578,7 @@ impl ProverConfig {
                     timeout,
                     whitelist,
                     whitelist_add_high_availability,
+                    whitelist_add_default,
                 })
             }
             Some(invalid) => {
@@ -593,6 +673,9 @@ impl ProverConfig {
 
                 // Whitelist
                 match &net.whitelist {
+                    Some(addresses) if addresses.is_empty() => {
+                        info!("  Whitelist: (open - empty list sent, any prover can participate)");
+                    }
                     Some(addresses) => {
                         info!("  Whitelist:");
                         for addr in addresses {
@@ -606,6 +689,16 @@ impl ProverConfig {
                             }
                             false => {
                                 info!("  Whitelist add high availability: false");
+                            }
+                        }
+
+                        // Whitelist add default pool
+                        match &net.whitelist_add_default {
+                            true => {
+                                info!("  Whitelist add default pool: true");
+                            }
+                            false => {
+                                info!("  Whitelist add default pool: false");
                             }
                         }
                     }

--- a/nori/src/sp1_prover_config.rs
+++ b/nori/src/sp1_prover_config.rs
@@ -50,6 +50,7 @@ const ENV_SP1_SKIP_SIMULATION: &str = "SP1_SKIP_SIMULATION"; // Maps to ProveReq
 const ENV_SP1_TIMEOUT_SECS: &str = "SP1_TIMEOUT_SECS"; // Maps to ProveRequest.timeout()
 const ENV_SP1_MAX_PRICE_PER_PGU: &str = "SP1_MAX_PRICE_PER_PGU";
 const ENV_SP1_AUCTION_TIMEOUT_SECS: &str = "SP1_AUCTION_TIMEOUT_SECS"; // Maps to auction timeout
+const ENV_SP1_MIN_AUCTION_PERIOD_SECS: &str = "SP1_MIN_AUCTION_PERIOD_SECS"; // Maps to ProveRequest.min_auction_period()
 const ENV_SP1_WHITELIST: &str = "SP1_WHITELIST"; // Maps to ProveRequest.whitelist()
 
 // A custom env (a boolean) to use a query to add the provers with the best uptime (high_availability_only: true) to the whitelist before starting
@@ -64,6 +65,7 @@ const SDK_DEFAULT_PRICE_PER_PGU: u64 = 1_000_000_000; //Max price per bPGU: 1000
 const SDK_MAINNET_RPC_URL: &str = "https://rpc.mainnet.succinct.xyz"; // Line 67
 const SDK_RESERVED_RPC_URL: &str = "https://rpc.production.succinct.xyz"; // Line 69
 const SDK_DEFAULT_AUCTION_TIMEOUT_SECS: u64 = 30; // Line 76: Duration::from_secs(30) / or 1sec TODO?
+const SDK_DEFAULT_MIN_AUCTION_PERIOD_SECS: u64 = 1; // SDK default per Succinct docs: wait at least 1s before settling auction
 
 const SDK_MAINNET_DEFAULT_CYCLE_LIMIT: u64 = 1_000_000_000_000; // Line 77
 const SDK_RESERVED_DEFAULT_CYCLE_LIMIT: u64 = 100_000_000; // Line 78
@@ -93,7 +95,10 @@ pub enum ProofType {
 }
 
 pub enum FulfillmentConfig {
-    Auction { timeout: Duration },
+    Auction {
+        timeout: Duration,
+        min_auction_period: u64,
+    },
     Hosted,
     Reserved,
 }
@@ -300,6 +305,20 @@ impl ProverConfig {
                     },
                 };
 
+                // Get min auction period from environment, defaults to SDK_DEFAULT_MIN_AUCTION_PERIOD_SECS (1)
+                // Reference: sp1-sdk-6.1.0/src/network/prove.rs:238 (min_auction_period method, takes u64 seconds)
+                // Behaviour: parse as u64 or error on invalid, use default if missing.
+                // Only meaningful when fulfillment strategy is auction; ignored otherwise.
+                let min_auction_period = match env::var(ENV_SP1_MIN_AUCTION_PERIOD_SECS) {
+                    Ok(val) => val.parse::<u64>().with_context(|| {
+                        format!(
+                            "Failed to parse {} as u64. Got: '{}'",
+                            ENV_SP1_MIN_AUCTION_PERIOD_SECS, val
+                        )
+                    })?,
+                    Err(_) => SDK_DEFAULT_MIN_AUCTION_PERIOD_SECS,
+                };
+
                 // Get fulfillment strategy from environment
                 // Reference: sp1-sdk-5.2.2/src/network/prover.rs:98-102 (default_fulfillment_strategy)
                 // Behaviour: Pick from 'auction', 'hosted', or 'reserved'. Default based on network mode
@@ -318,6 +337,7 @@ impl ProverConfig {
                         };
                         FulfillmentConfig::Auction {
                             timeout: Duration::from_secs(secs),
+                            min_auction_period,
                         }
                     }
                     Some("hosted") => FulfillmentConfig::Hosted,
@@ -332,6 +352,7 @@ impl ProverConfig {
                     None => match network_mode {
                         NetworkMode::Mainnet => FulfillmentConfig::Auction {
                             timeout: Duration::from_secs(SDK_DEFAULT_AUCTION_TIMEOUT_SECS),
+                            min_auction_period,
                         },
                         NetworkMode::Reserved => FulfillmentConfig::Reserved,
                     },
@@ -536,10 +557,14 @@ impl ProverConfig {
 
                 // Fulfillment strategy
                 match &net.fulfillment {
-                    FulfillmentConfig::Auction { timeout } => {
+                    FulfillmentConfig::Auction {
+                        timeout,
+                        min_auction_period,
+                    } => {
                         info!(
-                            "  Fulfillment Strategy: auction (timeout: {}s)",
-                            timeout.as_secs()
+                            "  Fulfillment Strategy: auction (timeout: {}s, min_auction_period: {}s)",
+                            timeout.as_secs(),
+                            min_auction_period
                         );
                     }
                     FulfillmentConfig::Hosted => {

--- a/nori/src/sp1_prover_config.rs
+++ b/nori/src/sp1_prover_config.rs
@@ -1,7 +1,7 @@
 use alloy::signers::local::PrivateKeySigner;
 use alloy_primitives::Address;
 use anyhow::{Context, Result};
-use log::info;
+use log::{info, warn};
 use reqwest::Url;
 use sp1_sdk::network::{
     proto::{
@@ -515,7 +515,15 @@ impl ProverConfig {
                             })
                         },
                     )?,
-                    None => false,
+                    None => {
+                        if env::var(ENV_SP1_WHITELIST_ADD_HIGH_AVAILABILITY).ok().as_deref() == Some("true") {
+                            warn!(
+                                "{} is set but {} is not provided. The flag has no effect without a whitelist to extend.",
+                                ENV_SP1_WHITELIST_ADD_HIGH_AVAILABILITY, ENV_SP1_WHITELIST
+                            );
+                        }
+                        false
+                    },
                 };
 
                 // If a whitelist is provided, optionally include the SDK default pool of
@@ -533,7 +541,15 @@ impl ProverConfig {
                             })
                         },
                     )?,
-                    None => false,
+                    None => {
+                        if env::var(ENV_SP1_WHITELIST_ADD_DEFAULT).ok().as_deref() == Some("true") {
+                            warn!(
+                                "{} is set but {} is not provided. The flag has no effect without a whitelist to extend.",
+                                ENV_SP1_WHITELIST_ADD_DEFAULT, ENV_SP1_WHITELIST
+                            );
+                        }
+                        false
+                    },
                 };
 
                 // SP1_WHITELIST_OPEN: when true with no SP1_WHITELIST, send an empty whitelist


### PR DESCRIPTION
Adds support for a configurable minimum auction period, allowing the auction to stay open long enough for multiple bidders to compete before settling. Defaults to 1 second; recommended 10-15 seconds when latency is not a concern for better price discovery.

Adds support for setting the whitelist of provers to open, which allows any prover to bid on the request.

Adds support for setting the whitelist to default SDK one. Used to be able to extend the default SDK list by passing particular prover address using SP1_WHITELIST

more in README.md