### PR TITLE
FIX: Audit A2090 - Non-standard Merkle zero indexing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,20 @@ Results:
 - Cross-reference (unpatched Rust vs unpatched TypeScript non-provable): 51 leaf counts, all leaves and roots match. Zero differences.
 - Cross-reference (unpatched Rust vs unpatched TypeScript provable): 11 leaf counts (0-10), all leaves and roots match. Zero differences.
 
+### Commit 2 - Fix applied
+
+- **`zeros[level]` corrected to `zeros[depth + 1 - level]`** (`nori-hash/src/merkle_poseidon_fixed.rs`): three sites patched in `fold_merkle_left` (line 137), `build_merkle_tree` (line 230), and `get_merkle_path_from_leaves` (line 327). When the tree-building loop is at a given `level` counting down from `depth`, the parent node of two dummy children represents an all-zero subtree of height `depth + 1 - level`. The corrected index selects the matching precomputed zero hash from `get_merkle_zeros`.
+
+Results:
+
+- Regression tests: 2 pass, 0 fail (`regression_a2090_bruteforce_reference`, `regression_a2090_recursive_reference`). All leaf counts [1, 3, 5, 6, 9, 17] now match both the brute-force and recursive references for both `build_merkle_tree` and `fold_merkle_left` (24 checks, 24 pass).
+- Self-consistency (Rust): passes 0-50 leaves.
+- Self-consistency (TypeScript non-provable): passes 0-50 leaves.
+- Self-consistency (TypeScript provable): passes 0-10 leaves.
+- Cross-reference (patched Rust vs patched TypeScript non-provable): 51 leaf counts, 0 leaf mismatches, 0 root mismatches.
+- Cross-reference (patched Rust vs patched TypeScript provable): 51 leaf counts checked, 0 root mismatches, 40 leaf mismatches (all MISSING, provable suite only runs 0-10, no data exists for 11-50), 11 overlapping leaf counts all leaves and roots match.
+- Cross-reference (patched TypeScript non-provable vs patched TypeScript provable): 51 leaf counts checked, 0 root mismatches, 40 leaf mismatches (all MISSING, provable suite only runs 0-10, no data exists for 11-50), 11 overlapping leaf counts all leaves and roots match.
+
 ## 23/4/26 — Bridge SDK ref update + genesis_root commitment
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,94 @@
 # Changelog
 
-23/4/26 — Bridge SDK ref update + genesis_root commitment
+## 15/5/26 - Audit A2090: Non-standard Merkle zero indexing
+
+### Finding (verbatim)
+
+Finding a2090: `buildMerkleTree` uses the `zeros` array backwards
+
+Hi, we noticed an issue in nori-bridge-sdk\o1js-zk-utils\src\merkle-attestor\merkleTree.ts. When using zero hash while building the Merkle tree, the incorrect level/index is used.
+
+In buildMerkleTree (and also foldMerkleLeft and getMerklePathFromLeaves), zeros is set to be getMerkleZeros(depth) by the caller, which generates an array of Hashes that correspond to all-zero subtrees.
+
+```typescript
+/**
+ * Generate zero hashes array of length depth + 1
+ */
+export function getMerkleZeros(depth: number): Field[] {
+    const zeros: Field[] = [];
+
+    // Start with zeros[0] = Field(0)
+    zeros.push(Field(0));
+
+    for (let i = 1; i < depth + 1; i++) {
+        // Each next zero is hash of the previous zero with itself
+        zeros.push(Poseidon.hash([zeros[i - 1], zeros[i - 1]]));
+    }
+
+    return zeros;
+}
+```
+
+Notice that the array is ordered from smallest subtree (tree with a single 0 node, depth 0) to largest (tree of depth depth, i.e. depth+1 levels).
+
+However, in buildMerkleTree, when utilizing the zeros array, the following snippet is used:
+
+```typescript
+for (let level = depth; level > 0; level--) {
+    // Omitted...
+
+    for (let i = 0; i < parentWidth; i++) {
+        const leftIdx = 2 * i;
+
+        if (leftIdx >= nNonDummyNodes) {
+            // Both left and right dummy nodes, use zeros cache
+            parentLevel[i] = zeros[level];
+        } else {
+            // Omitted...
+        }
+    }
+    // Omitted...
+}
+```
+
+The zeros array is used backwards. e.g., when level=depth, the child level is the bottom layer of the tree, and the parent level is the layer above and hence should use zeros[1], hash that corresponds to a subtree of depth 1. Instead, the current code uses zeros[level], which is the hash for a subtree of depth depth.
+
+This leads to a completeness issue. The Mina bridge's off-chain witness builder uses this helper to derive deposit proofs, and noriMint() later recomputes the root on-chain and requires it to match the verified Ethereum deposit root. Whenever the number of leaves in the tree is not a power of 2 (i.e., there are dummy nodes in the tree), due to this incorrect calculation of the Merkle root, valid deposits would become unmintable even though the Ethereum proof and deposit data are correct.
+
+The fix is relatively straightforward: either reverse the order of the result of getMerkleZeros, or replace parentLevel[i] = zeros[level]; with parentLevel[i] = zeros[depth + 1 - level];.
+
+### Response
+
+The non-standard indexing is acknowledged. The same reversed indexing exists symmetrically in both the TypeScript (`merkleTree.ts`) and Rust (`merkle_poseidon_fixed.rs`) implementations across all three affected functions: `buildMerkleTree`/`build_merkle_tree`, `foldMerkleLeft`/`fold_merkle_left`, and `getMerklePathFromLeaves`/`get_merkle_path_from_leaves`. Because both producers in this closed system use the same non-standard convention, the computed roots agree across languages for all leaf counts. We do not believe there is a soundness or completeness failure in the deployed system. If the bug were asymmetric, failures would appear at any non-power-of-two count leaving adjacent dummies, the smallest being n=5, then 6, 9, 10, 11, 12, 13. Applying the proposed fix to only one side would introduce the completeness failure described in the report. The mistake cancels out leaving it safe as written but highly non-standard. Worth fixing but needs to be done carefully to avoid regression of the mint function.
+
+### Discussion
+
+After discussion it was noted that the two cited tests are not sufficient to rule out cross-language divergence when run in isolation, as each only checks self-consistency within its own language. This is agreed. The tests were not designed to be used in isolation. They were designed to be used in concert: the raw output from any two of the three test suites (Rust, TypeScript non-provable, TypeScript provable) was compared using an uncommitted comparison script that normalised and diffed leaves and roots line-by-line across languages. An improved version of this script (`nori-bridge-sdk/o1js-zk-utils/test/cross-reference-roots.sh`) is now committed to nori-bridge-sdk for transparency.
+
+Three test suites cover this code:
+
+1. Rust - `cargo test -p nori-hash test_all_leaf_counts_and_indices_with_build_and_fold` (n_leaves 0-50)
+2. TypeScript (non-provable) - `npm run test -- -t "test_all_leaf_counts_and_indices_with_build_and_fold"` (n_leaves 0-50)
+3. TypeScript (provable) - `npm run test -- -t "test_all_leaf_counts_and_indices_with_pipeline"` (n_leaves 0-10, truncated for speed; previously run to 50)
+
+This cross-referencing is a sample-based confidence check, not a claim of completeness proof.
+
+The finding correctly identifies a deviation from the standard Merkle zero-hash convention. While harmless in the current closed two-implementation system, non-standard indexing would be a problem for any future third-party verifier or public auditability tooling that assumes the standard convention. The fix is accepted and will be applied to both sides simultaneously. Testing will be bolstered first (commit 1) to expose the non-standard indexing against independent reference implementations, then the fix applied (commit 2), so that the before and after results can be documented in this summary.
+
+### Commit 1 - Test exposure of the non-standard indexing
+
+- **Regression tests** (`nori-hash/src/merkle_poseidon_fixed.rs`): added `regression_a2090_bruteforce_reference` and `regression_a2090_recursive_reference` tests over leaf counts [1, 3, 5, 6, 9, 17] verifying `build_merkle_tree` and `fold_merkle_left` against two independent reference implementations. The brute-force reference pads with zeros and hashes every pair with no zeros cache. The recursive reference builds the tree top-down, returning `Fp(0)` for empty subtrees. Neither references the zeros array. Leaf counts 5, 6, 9, 17 exercise the bug (adjacent dummy nodes at various depths); 1 and 3 are sanity cases where only a lone dummy pairs with a real leaf.
+
+Results:
+
+- Regression tests: n_leaves 1 and 3 pass (no adjacent dummies, 8 pass). n_leaves 5, 6, 9, 17 fail against both the brute-force and recursive references for both `build_merkle_tree` and `fold_merkle_left` (8 failures per reference, 16 fail, 24 total checks), confirming the non-standard indexing is detectable and diverges from the standard convention.
+- Self-consistency (Rust): passes 0-50 leaves.
+- Self-consistency (TypeScript non-provable): passes 0-50 leaves.
+- Self-consistency (TypeScript provable): passes 0-10 leaves.
+- Cross-reference (unpatched Rust vs unpatched TypeScript non-provable): 51 leaf counts, all leaves and roots match. Zero differences.
+- Cross-reference (unpatched Rust vs unpatched TypeScript provable): 11 leaf counts (0-10), all leaves and roots match. Zero differences.
+
+## 23/4/26 — Bridge SDK ref update + genesis_root commitment
 
 ### Added
 

--- a/nori-hash/src/merkle_poseidon_fixed.rs
+++ b/nori-hash/src/merkle_poseidon_fixed.rs
@@ -134,7 +134,7 @@ pub fn fold_merkle_left(
             if left_idx >= n_non_dummy_nodes {
                 // We are a dummy node and by virtue so is right_idx
                 // rather than computing the posiedon hash we can look it up.
-                merkle_nodes[i] = zeros[level];
+                merkle_nodes[i] = zeros[depth + 1 - level];
                 //println!("Optimisation made 💪");
             } else {
                 let right_idx = i2 + 1;
@@ -227,7 +227,7 @@ pub fn build_merkle_tree(
             if left_idx >= n_non_dummy_nodes {
                 // We are a dummy node and by virtue so is right_idx
                 // rather than computing the posiedon hash we can look it up.
-                parent_level.push(zeros[level]);
+                parent_level.push(zeros[depth + 1 - level]);
                 //println!("Optimisation made 💪");
             } else {
                 let right_idx = i2 + 1;
@@ -324,7 +324,7 @@ pub fn get_merkle_path_from_leaves(
             if left_idx >= n_non_dummy_nodes {
                 // We are a dummy node and by virtue so is right_idx
                 // rather than computing the posiedon hash we can look it up.
-                merkle_nodes[i] = zeros[level];
+                merkle_nodes[i] = zeros[depth + 1 - level];
             } else {
                 let right_idx = i2 + 1;
                 // Atleast one is a real node

--- a/nori-hash/src/merkle_poseidon_fixed.rs
+++ b/nori-hash/src/merkle_poseidon_fixed.rs
@@ -708,6 +708,114 @@ mod merkle_fixed_tests {
             }
         }
     }
+
+    // Brute-force reference: pad with Fp(0), hash every pair, no zeros cache.
+    fn reference_root_bruteforce(leaves: &[Fp], padded_size: usize) -> Fp {
+        let mut level: Vec<Fp> = leaves.to_vec();
+        level.resize(padded_size, Fp::from(0));
+        while level.len() > 1 {
+            let mut next = Vec::with_capacity(level.len() / 2);
+            for i in (0..level.len()).step_by(2) {
+                next.push(poseidon_hash(&[level[i], level[i + 1]]));
+            }
+            level = next;
+        }
+        level[0]
+    }
+
+    // Recursive reference: computes the root of a subtree by recursion.
+    fn reference_root_recursive(leaves: &[Fp], padded_size: usize) -> Fp {
+        fn subtree(leaves: &[Fp], offset: usize, size: usize) -> Fp {
+            if size == 1 {
+                return if offset < leaves.len() {
+                    leaves[offset]
+                } else {
+                    Fp::from(0)
+                };
+            }
+            let half = size / 2;
+            let left = subtree(leaves, offset, half);
+            let right = subtree(leaves, offset + half, half);
+            poseidon_hash(&[left, right])
+        }
+        subtree(leaves, 0, padded_size)
+    }
+
+    // 1,3  - no dummy pairs (sanity)
+    // 5,6  - dummy pairs at depth 3
+    // 9    - dummy pairs at depth 4
+    // 17   - dummy pairs at depth 5
+    const REGRESSION_LEAF_COUNTS: &[i32] = &[1, 3, 5, 6, 9, 17];
+
+    #[test]
+    fn regression_a2090_bruteforce_reference() {
+        let zeros = get_merkle_zeros();
+        let mut failures: Vec<String> = Vec::new();
+        for &n_leaves in REGRESSION_LEAF_COUNTS {
+            let pairs: Vec<(U256, U256)> = (0..n_leaves)
+                .map(|i| (dummy_code_challenge(i), dummy_value(i)))
+                .collect();
+            let leaves = build_leaves(&pairs).expect("build_leaves failed");
+            let (depth, padded_size) = compute_merkle_tree_depth_and_size(leaves.len());
+
+            let expected = reference_root_bruteforce(&leaves, padded_size);
+
+            let tree = build_merkle_tree(leaves.clone(), padded_size, depth, &zeros);
+            if tree[0][0] != expected {
+                failures.push(format!(
+                    "[n_leaves={}] build_merkle_tree root does not match brute-force reference",
+                    n_leaves
+                ));
+            }
+
+            let mut leaves_for_fold = leaves.clone();
+            let root_fold = fold_merkle_left(&mut leaves_for_fold, padded_size, depth, &zeros);
+            if root_fold != expected {
+                failures.push(format!(
+                    "[n_leaves={}] fold_merkle_left root does not match brute-force reference",
+                    n_leaves
+                ));
+            }
+        }
+        if !failures.is_empty() {
+            panic!("{} failures:\n{}", failures.len(), failures.join("\n"));
+        }
+    }
+
+    #[test]
+    fn regression_a2090_recursive_reference() {
+        let zeros = get_merkle_zeros();
+        let mut failures: Vec<String> = Vec::new();
+        for &n_leaves in REGRESSION_LEAF_COUNTS {
+            let pairs: Vec<(U256, U256)> = (0..n_leaves)
+                .map(|i| (dummy_code_challenge(i), dummy_value(i)))
+                .collect();
+            let leaves = build_leaves(&pairs).expect("build_leaves failed");
+            let (depth, padded_size) = compute_merkle_tree_depth_and_size(leaves.len());
+
+            let expected = reference_root_recursive(&leaves, padded_size);
+
+            let tree = build_merkle_tree(leaves.clone(), padded_size, depth, &zeros);
+            if tree[0][0] != expected {
+                failures.push(format!(
+                    "[n_leaves={}] build_merkle_tree root does not match recursive reference",
+                    n_leaves
+                ));
+            }
+
+            let mut leaves_for_fold = leaves.clone();
+            let root_fold = fold_merkle_left(&mut leaves_for_fold, padded_size, depth, &zeros);
+            if root_fold != expected {
+                failures.push(format!(
+                    "[n_leaves={}] fold_merkle_left root does not match recursive reference",
+                    n_leaves
+                ));
+            }
+        }
+        if !failures.is_empty() {
+            panic!("{} failures:\n{}", failures.len(), failures.join("\n"));
+        }
+    }
 }
 
 /// STATICALLY BUILT ZEROS


### PR DESCRIPTION
## Finding

A2090: `build_merkle_tree` uses the `zeros` array backwards.

Rust-side counterpart to the TypeScript fix in nori-bridge-sdk. The same reversed zeros indexing exists in `fold_merkle_left`, `build_merkle_tree`, and `get_merkle_path_from_leaves` in `nori-hash/src/merkle_poseidon_fixed.rs`. The fix will be applied to both sides simultaneously.

## Resolution

- acc1997 - Commit 1: regression tests exposing non-standard zeros indexing (8 pass, 16 fail, 24 total checks)
- 5843416 - Commit 2: `zeros[level]` corrected to `zeros[depth + 1 - level]` in 3 sites, all regression tests pass (24 checks, 24 pass)

See [CHANGELOG.md](https://github.com/Nori-zk/nori-bridge-head/blob/FIX/audit-a2090/CHANGELOG.md#15526---audit-a2090-non-standard-merkle-zero-indexing) for the full finding (verbatim), response, discussion, and detailed results.